### PR TITLE
build-image: Use 'OKD_VERSION' instead hard code version

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -66,4 +66,9 @@ jobs:
         pushd okd-arm64
         chmod +x build-images.sh
         ./build-images.sh
+        popd
+    - name: build microshift image and push
+      run: |
+        ./create-microshift-image.sh
+
 

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -51,9 +51,6 @@ jobs:
         echo "Verifying Skopeo"
         skopeo --version
 
-    - name: Set up QEMU static binaries
-      uses: docker/setup-qemu-action@v3
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -65,7 +65,13 @@ jobs:
         ./build-images.sh
         popd
     - name: build microshift image and push
+      id: image
       run: |
         ./create-microshift-image.sh
+    - name: Setup tmate session
+      if: ${{ failure() && steps.image.conclusion == 'failure' }}
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 
 

--- a/.github/workflows/build_images_amd64.yaml
+++ b/.github/workflows/build_images_amd64.yaml
@@ -1,0 +1,65 @@
+name: Build the microshift image for amd64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  setup-tools:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Set up Podman, OpenShift CLI, and Skopeo
+      run: |
+        echo "Installing Podman and skopeo"
+        sudo apt-get update
+        sudo apt-get install -y podman skopeo
+
+    - name: Remove unwanted stuff to free up disk image
+      run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          sudo docker image prune --all --force
+
+          sudo swapoff -a
+          sudo rm -f /mnt/swapfile
+
+    - name: Verify installations
+      run: |
+        echo "Verifying Podman"
+        podman --version
+
+        echo "Verifying Skopeo"
+        skopeo --version
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.sha }}
+
+    - name: Log in to Quay.io
+      env:
+        USERNAME: ${{ secrets.USERNAME }}
+        PASSWORD: ${{ secrets.PASSWORD }}
+      uses: redhat-actions/podman-login@v1
+      with:
+        username: ${{ env.USERNAME }}
+        password: ${{ env.PASSWORD }}
+        registry: "quay.io"
+    - name: build microshift image and push
+      id: image
+      run: |
+        ./create-microshift-image.sh
+    - name: Setup tmate session
+      if: ${{ failure() && steps.image.conclusion == 'failure' }}
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
+
+

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Detect the system architecture
+ARCH=$(uname -m)
+
+# Map system architectures to container image architectures
+case "$ARCH" in
+  "x86_64")
+    ARCH="amd64"
+    REPO="registry.ci.openshift.org/origin/release-scos"
+    ;;
+  "aarch64")
+    ARCH="arm64"
+    REPO="quay.io/okd-arm/okd-arm-release"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# Variables
+VERSION_TAG="4.18.0-0.okd-scos-2025-01-28-033610"
+IMAGE_NAME="quay.io/praveenkumar/microshift-okd"
+IMAGE_ARCH_TAG="${IMAGE_NAME}:${VERSION_TAG}-${ARCH}"
+CONTAINERFILE="okd/src/microshift-okd-multi-build.Containerfile"
+
+echo "Building image for architecture: $ARCH using repository: $REPO"
+
+git clone https://github.com/openshift/microshift
+pushd microshift
+
+# Build the image
+podman build \
+  --build-arg OKD_REPO="$REPO" \
+  --build-arg OKD_VERSION_TAG="$VERSION_TAG" \
+  --env WITH_FLANNEL=1 \
+  --env EMBED_CONTAINER_IMAGES=1 \
+  --file "$CONTAINERFILE" \
+  --tag "$IMAGE_ARCH_TAG" \
+  .
+
+# Push the image
+echo "Pushing image: $IMAGE_ARCH_TAG"
+podman push "$IMAGE_ARCH_TAG"
+popd
+
+rm -fr microshift
+

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -32,6 +32,9 @@ echo "Building image for architecture: $ARCH using repository: $REPO"
 git clone https://github.com/openshift/microshift
 pushd microshift
 
+# https://github.com/openshift/microshift/pull/4494
+sed -i '/RUN useradd -m -s \/bin\/bash microshift -d \/microshift && \\/!b;n;c\    echo '\''microshift  ALL=(ALL)  NOPASSWD: ALL'\'' >\/etc\/sudoers.d\/microshift \&\& \\\n    chmod 0640 \/etc\/shadow' "${CONTAINERFILE}"
+
 # Build the image
 podman build \
   --build-arg OKD_REPO="$REPO" \

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -10,7 +10,7 @@ SKOPEO=${SKOPEO:-skopeo}
 PODMAN=${PODMAN:-podman}
 BRANCH=${BRANCH:-release-4.18}
 # Get the version from https://amd64.origin.releases.ci.openshift.org/
-OKD_VERSION=${OKD_VERSION:-4.18.0-0.okd-scos-2024-11-27-190430}
+OKD_VERSION=${OKD_VERSION:-4.18.0-0.okd-scos-2025-01-28-033610}
 
 check_dependency() {
   if ! which ${OC}; then

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -287,7 +287,7 @@ check_dependency
 login_to_registry
 
 # check if image already exist
-if skopeo inspect --format "Digest: {{.Digest}}" docker://quay.io/okd-arm/okd-arm-release:${OKD_VERSION}; then
+if skopeo --override-os="linux" --override-arch="amd64" inspect --format "Digest: {{.Digest}}" docker://quay.io/okd-arm/okd-arm-release:${OKD_VERSION}; then
    echo "image quay.io/okd-arm/okd-arm-release:${OKD_VERSION} already exist"
    exit 0
 fi

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -237,7 +237,7 @@ update_image_tag_to_sha() {
 
 # Create a new release of okd using oc
 create_new_okd_release() {
-    oc adm release new --from-release registry.ci.openshift.org/origin/release-scos:scos-4.18 \
+    oc adm release new --from-release registry.ci.openshift.org/origin/release-scos:${OKD_VERSION} \
        --keep-manifest-list \
        cli="${images[cli]}" \
 	haproxy-router="${images[haproxy-router]}" \


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Use the `OKD_VERSION` environment variable when creating a new OKD release.