### PR TITLE
Debug: image cahce not working

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -73,5 +73,6 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
+        timeout-minutes: 15
 
 

--- a/.github/workflows/build_images_amd64.yaml
+++ b/.github/workflows/build_images_amd64.yaml
@@ -61,5 +61,6 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
+        timeout-minutes: 15
 
 

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -37,6 +37,7 @@ sed -i '/RUN useradd -m -s \/bin\/bash microshift -d \/microshift && \\/!b;n;c\ 
 
 # Build the image
 podman build \
+  --ulimit nofile=100000:65536
   --build-arg OKD_REPO="$REPO" \
   --build-arg OKD_VERSION_TAG="$VERSION_TAG" \
   --env WITH_FLANNEL=1 \
@@ -51,4 +52,4 @@ podman push "$IMAGE_ARCH_TAG"
 popd
 
 rm -fr microshift
-
+exit 1

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -22,7 +22,7 @@ case "$ARCH" in
 esac
 
 # Variables
-VERSION_TAG="4.18.0-0.okd-scos-2025-01-28-033610"
+VERSION_TAG="4.18.0-0.okd-scos-2025-01-30-153612"
 IMAGE_NAME="quay.io/praveenkumar/microshift-okd"
 IMAGE_ARCH_TAG="${IMAGE_NAME}:${VERSION_TAG}-${ARCH}"
 CONTAINERFILE="okd/src/microshift-okd-multi-build.Containerfile"

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -36,8 +36,7 @@ pushd microshift
 sed -i '/RUN useradd -m -s \/bin\/bash microshift -d \/microshift && \\/!b;n;c\    echo '\''microshift  ALL=(ALL)  NOPASSWD: ALL'\'' >\/etc\/sudoers.d\/microshift \&\& \\\n    chmod 0640 \/etc\/shadow' "${CONTAINERFILE}"
 
 # Build the image
-podman build \
-  --ulimit nofile=100000:65536
+sudo podman build \
   --build-arg OKD_REPO="$REPO" \
   --build-arg OKD_VERSION_TAG="$VERSION_TAG" \
   --env WITH_FLANNEL=1 \
@@ -48,8 +47,7 @@ podman build \
 
 # Push the image
 echo "Pushing image: $IMAGE_ARCH_TAG"
-podman push "$IMAGE_ARCH_TAG"
+sudo podman push "$IMAGE_ARCH_TAG"
 popd
 
 rm -fr microshift
-exit 1

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -27,6 +27,12 @@ IMAGE_NAME="quay.io/praveenkumar/microshift-okd"
 IMAGE_ARCH_TAG="${IMAGE_NAME}:${VERSION_TAG}-${ARCH}"
 CONTAINERFILE="okd/src/microshift-okd-multi-build.Containerfile"
 
+# check if image already exist
+if skopeo --override-os="linux" --override-arch="${ARCH}" inspect --format "Digest: {{.Digest}}" docker://${IMAGE_ARCH_TAG}; then
+   echo "${IMAGE_ARCH_TAG} already exist"
+   exit 0
+fi
+
 echo "Building image for architecture: $ARCH using repository: $REPO"
 
 git clone https://github.com/openshift/microshift

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -10,7 +10,7 @@ SKOPEO=${SKOPEO:-skopeo}
 PODMAN=${PODMAN:-podman}
 BRANCH=${BRANCH:-release-4.18}
 # Get the version from https://amd64.origin.releases.ci.openshift.org/
-OKD_VERSION=${OKD_VERSION:-4.18.0-0.okd-scos-2025-01-28-033610}
+OKD_VERSION=${OKD_VERSION:-4.18.0-0.okd-scos-2025-01-30-153612}
 
 check_dependency() {
   if ! which ${OC}; then


### PR DESCRIPTION
## Summary by Sourcery

Increase the ulimit for open files during the image build and force the script to exit with a non-zero code.

Build:
- Increase the ulimit for open files during image build using `--ulimit nofile=100000:65536`.
- Force the script to exit with a non-zero code using `exit 1`.