### PR TITLE
Update OKD version to 4.18.0-okd-scos.0

### DIFF
--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -22,7 +22,7 @@ case "$ARCH" in
 esac
 
 # Variables
-VERSION_TAG="4.18.0-0.okd-scos-2025-01-30-153612"
+VERSION_TAG="4.18.0-okd-scos.0"
 IMAGE_NAME="quay.io/praveenkumar/microshift-okd"
 IMAGE_ARCH_TAG="${IMAGE_NAME}:${VERSION_TAG}-${ARCH}"
 CONTAINERFILE="okd/src/microshift-okd-multi-build.Containerfile"

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -38,9 +38,6 @@ echo "Building image for architecture: $ARCH using repository: $REPO"
 git clone https://github.com/openshift/microshift
 pushd microshift
 
-# https://github.com/openshift/microshift/pull/4494
-sed -i '/RUN useradd -m -s \/bin\/bash microshift -d \/microshift && \\/!b;n;c\    echo '\''microshift  ALL=(ALL)  NOPASSWD: ALL'\'' >\/etc\/sudoers.d\/microshift \&\& \\\n    chmod 0640 \/etc\/shadow' "${CONTAINERFILE}"
-
 # Build the image
 sudo podman build \
   --build-arg OKD_REPO="$REPO" \

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -10,7 +10,7 @@ SKOPEO=${SKOPEO:-skopeo}
 PODMAN=${PODMAN:-podman}
 BRANCH=${BRANCH:-release-4.18}
 # Get the version from https://amd64.origin.releases.ci.openshift.org/
-OKD_VERSION=${OKD_VERSION:-4.18.0-0.okd-scos-2025-01-30-153612}
+OKD_VERSION=${OKD_VERSION:-4.18.0-okd-scos.0}
 
 check_dependency() {
   if ! which ${OC}; then


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the OKD version used in the `create-microshift-image.sh` and `build-images.sh` scripts.