### PR TITLE
Build image for 4.18.0-okd-scos.1

### DIFF
--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -22,7 +22,7 @@ case "$ARCH" in
 esac
 
 # Variables
-VERSION_TAG="4.18.0-okd-scos.0"
+VERSION_TAG="4.18.0-okd-scos.1"
 IMAGE_NAME="quay.io/praveenkumar/microshift-okd"
 IMAGE_ARCH_TAG="${IMAGE_NAME}:${VERSION_TAG}-${ARCH}"
 CONTAINERFILE="okd/src/microshift-okd-multi-build.Containerfile"

--- a/okd-arm64/build-images.sh
+++ b/okd-arm64/build-images.sh
@@ -10,7 +10,7 @@ SKOPEO=${SKOPEO:-skopeo}
 PODMAN=${PODMAN:-podman}
 BRANCH=${BRANCH:-release-4.18}
 # Get the version from https://amd64.origin.releases.ci.openshift.org/
-OKD_VERSION=${OKD_VERSION:-4.18.0-okd-scos.0}
+OKD_VERSION=${OKD_VERSION:-4.18.0-okd-scos.1}
 
 check_dependency() {
   if ! which ${OC}; then


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the image version to `4.18.0-okd-scos.1` in the build scripts.