### PR TITLE
Update readme with new image and remvoe dns/storage config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,32 +24,13 @@ Get the openshift client binary:
 - Windows: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-windows.zip
 - Mac: https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/latest/openshift-client-mac-arm64.tar.gz
 
-Get the dns config:
--------------------
-
-This is going to mounted on the container
-
-```bash
-curl -L -O https://raw.githubusercontent.com/praveenkumar/minp/refs/heads/main/00-dns.yaml
-```
-
-Get the storage config:
-----------------------
-
-This is going to mounted on the container to share the image store from host to container.
-This config file is taken from https://github.com/containers/storage/blob/main/storage.conf and
-added the info about `additionalimagestores` option.
-
-```bash
-curl -L -O https://raw.githubusercontent.com/praveenkumar/minp/refs/heads/main/storage.conf
-```
 
 Running the image:
 ----------------
 
 For Windows:
 ```
-podman run --hostname 127.0.0.1.nip.io --detach --rm -it --privileged -v 00-dns.yaml:/etc/microshift/config.d/00-dns.yaml:ro -p 9080:80 -p 9443:443 -p 6443:6443 --name microshift quay.io/praveenkumar/microshift-okd:flannel-amd64
+podman run --hostname 127.0.0.1.nip.io --detach --rm -it --privileged -v /var/lib/containers/storage:/host-container:ro,rshared -p 9080:80 -p 9443:443 -p 6443:6443 --name microshift quay.io/praveenkumar/microshift-okd:4.18.0-okd-scos.1-amd64
 sleep 20
 podman cp microshift:/var/lib/microshift/resources/kubeadmin/127.0.0.1.nip.io/kubeconfig .
 oc.exe --kubeconfig=kubeconfig get pods -A
@@ -57,7 +38,7 @@ oc.exe --kubeconfig=kubeconfig get pods -A
 
 For Mac:
 ```
-podman run --hostname 127.0.0.1.nip.io --detach --rm -it --privileged -v 00-dns.yaml:/etc/microshift/config.d/00-dns.yaml:ro -p 9080:80 -p 9443:443 -p 6443:6443 --name microshift quay.io/praveenkumar/microshift-okd:flannel-arm64
+podman run --hostname 127.0.0.1.nip.io --detach --rm -it --privileged -v /var/lib/containers/storage:/host-container:ro,rshared -p 9080:80 -p 9443:443 -p 6443:6443 --name microshift quay.io/praveenkumar/microshift-okd:4.18.0-okd-scos.1-arm64
 sleep 20
 podman cp microshift:/var/lib/microshift/resources/kubeadmin/127.0.0.1.nip.io/kubeconfig .
 oc --kubeconfig=kubeconfig get pods -A


### PR DESCRIPTION
## Summary by Sourcery

This pull request updates the README with a new container image version and removes the DNS and storage configuration sections. It also updates the `podman run` command to mount the host's container storage directory into the container.

Enhancements:
- Updated the container image version in the `podman run` command for both Windows and Mac.
- The `podman run` command now mounts the host's container storage directory into the container.

Chores:
- Removed the DNS and storage configuration sections from the README.